### PR TITLE
Ingest rewrite

### DIFF
--- a/gwcli/CONTRIBUTING.md
+++ b/gwcli/CONTRIBUTING.md
@@ -38,7 +38,8 @@ Tree nodes (commands that require further input/are submenus), such as `user`, a
 
 # Build System
 
-gwcli uses [Mage](magefile.org) as its build system. Because go's tooling so robust, you don't *really* need mage, but it has some extra utilities for testing. You can explore it by installing mage and calling `mage -h`/`mage -h <cmd>`.
+gwcli uses [Mage](magefile.org) as its build system. Because go's tooling is so robust, you don't *really* need mage, but it has some extra utilities for testing. You can explore it by installing mage and calling `mage -h`/`mage -h <cmd>`.
+
 
 # Changing the Command Tree
 

--- a/gwcli/TODO.md
+++ b/gwcli/TODO.md
@@ -11,6 +11,7 @@
     - the filepicker bubble is fairly barebones. It has no real ability to jump directories/allow a user to directly edit their path (this can be worked around by setting .CurrentDirectory and then calling Init(), but it clearly isn't intentional), does not export the readDir message for forcing a re-scan (hence the need to recall Init()), cannot select multiple items, and does not satisfy the help interface (despite being in the same repo as the help bubble).
     - Other quality of life features would be nice (ex: adding ".." as a select-able option for navigation).
     - The current version of FileGrabber has a commented-out skeleton of this kind of bubble at the bottom.
+    - See the [associated issue](https://github.com/gravwell/gravwell/issues/1733#issue-3164170133).
 
 - [ ] add flags to gwcli's suggestions list
     - gwcli can suggest/auto-complete navs, actions, and built-ins, but cannot suggest flags, flag values, or arguments. Flags values and arguments would be really tough as they are highly context dependent (flag X takes a directory, flag Y takes an arbitrary number, etc), but just adding completion for flags would be really useful.

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -105,9 +105,10 @@ func (i *ingest) Update(msg tea.Msg) tea.Cmd {
 			if i.ingestCount <= 0 { // all done
 				i.mode = done
 			}
+			return resultCmd
 		default: // no results ready, just spin
+			return i.spinner.Tick
 		}
-		return tea.Batch(i.spinner.Tick, resultCmd)
 	default: //case picking:
 		if keyMsg, ok := msg.(tea.KeyMsg); ok {
 			i.err = nil
@@ -232,7 +233,7 @@ func (i *ingest) pickerView() string {
 	newHeight := i.height - (breadcrumbHeight + modHeight + errHelpHeight + buffer)
 	i.fp.SetHeight(min(newHeight, maxHeight))
 
-	var s = lipgloss.JoinVertical(lipgloss.Center, sty.Render(i.fp.View()), i.errHelpView())
+	var s = lipgloss.JoinVertical(lipgloss.Center, sty.Render(i.fp.View()), sty.Render(i.errHelpView()))
 	if i.mod.focused {
 		return stylesheet.Cur.ComposableSty.UnfocusedBorder.
 			AlignHorizontal(lipgloss.Center).Render(s)

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -262,10 +262,11 @@ func (i *ingest) Reset() error {
 }
 
 // SetArgs places the filepicker in the user's pwd and sets defaults based on flag.
-func (i *ingest) SetArgs(_ *pflag.FlagSet, tokens []string) (string, tea.Cmd, error) {
+func (i *ingest) SetArgs(fs *pflag.FlagSet, tokens []string) (string, tea.Cmd, error) {
 	var err error
 
 	rawFlags := initialLocalFlagSet()
+	rawFlags.AddFlagSet(fs)
 	if err := rawFlags.Parse(tokens); err != nil {
 		return "", nil, err
 	}

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -270,9 +270,12 @@ func (i *ingest) SetArgs(_ *pflag.FlagSet, tokens []string) (string, tea.Cmd, er
 		return "", nil, err
 	}
 	flags, invalids, err := transmogrifyFlags(&rawFlags)
+	if err != nil {
+		return "", nil, err
+	}
 	if len(invalids) > 0 {
+		// concatenate invalids and return them
 		var full strings.Builder
-		// concatenate invalids
 		for _, reason := range invalids {
 			full.WriteString(reason + "\n")
 		}

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -127,6 +127,7 @@ func (i *ingest) Update(msg tea.Msg) tea.Cmd {
 			i.fp, cmd = i.fp.Update(msg)
 			// check for file selection (and thus, attempt ingestion)
 			if didSelect, path := i.fp.DidSelectFile(msg); didSelect {
+				// validate selections and modifiers prior to ingestion
 				if path == "" {
 					i.err = errEmptyPath
 					return cmd

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -294,7 +294,7 @@ func (i *ingest) SetArgs(_ *pflag.FlagSet, tokens []string) (string, tea.Cmd, er
 
 	// prepare the interactive action
 	i.mod.tagTI.SetValue(flags.defaultTag)
-	i.mod.srcTI.SetValue(flags.src.String())
+	i.mod.srcTI.SetValue(flags.src)
 
 	if flags.dir == "" {
 		i.fp.CurrentDirectory, err = os.Getwd()

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -128,7 +128,7 @@ func (i *ingest) Update(msg tea.Msg) tea.Cmd {
 			// check for file selection (and thus, attempt ingestion)
 			if didSelect, path := i.fp.DidSelectFile(msg); didSelect {
 				if path == "" {
-					i.err = errEmptyFile
+					i.err = errEmptyPath
 					return cmd
 				}
 				// check that src is empty or a valid IP

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -142,7 +142,11 @@ func (i *ingest) Update(msg tea.Msg) tea.Cmd {
 					}
 				}
 
-				tag := i.mod.tagTI.Value()
+				tag := strings.TrimSpace(i.mod.tagTI.Value())
+				if tag == "" {
+					i.err = errors.New("tag is required")
+					return cmd
+				}
 				if err := validateTag(tag); err != nil {
 					i.err = err
 					return cmd

--- a/gwcli/tree/ingest/actor.go
+++ b/gwcli/tree/ingest/actor.go
@@ -286,9 +286,10 @@ func (i *ingest) SetArgs(_ *pflag.FlagSet, tokens []string) (string, tea.Cmd, er
 
 	// if one+ files were given, try to ingest immediately
 	if len(pairs) > 0 {
-		ufErr := autoingest(i.ingestResCh, flags, pairs)
-		if ufErr != nil {
-			return ufErr.Error(), nil, nil
+		count := autoingest(i.ingestResCh, flags, pairs)
+		if count == 0 {
+			// should be impossible
+			panic("autoingest returned a count of 0")
 		}
 		i.ingestCount = len(pairs)
 		i.mode = ingesting

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -14,7 +14,7 @@ var (
 	errEmptyFile error = errors.New("cowardly refusing to ingest an empty file")
 	// a tag contained 1+ of the characters contained in illegalTagCharacters
 	errInvalidTagCharacter error = fmt.Errorf("tags cannot contain any of the following characters: %v", illegalTagCharacters)
-	// a
+	// failed to associate a tag to this file using any of the 3 methods (in-line, embedded, default)
 	errNoTagSpecified error = errors.New(
 		"every file must have a tag in at least one of the following positions (ordered by priority): " +
 			"as part of the argument (\"path,tag\"), embedded in the file (in the case of Gravwell JSON files), or via the --default-tag flag")

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -29,3 +29,8 @@ func errNoFilesSpecified(script bool) error {
 	}
 	return fmt.Errorf("at least 1 path must be specified%v", tail)
 }
+
+// thrown by ingest when it received a directory after supposedly collecting all files were collected
+func errUnwalkedDirectory(pth string) error {
+	return fmt.Errorf("'%v' is a directory, which should have been traversed prior. Please file a bug report.", pth)
+}

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -8,8 +8,12 @@ import (
 var illegalTagCharacters = []rune{' '}
 
 var (
-	errEmptyTag  error = errors.New("tag cannot be empty")
-	errEmptyFile error = errors.New("you must select a valid file for ingestion")
+	//errEmptyTag  error = errors.New("tag cannot be empty")
+
+	// file path cannot be empty
+	errEmptyPath error = errors.New("file path cannot be empty")
+	// refusing to ingest an empty file
+	errEmptyFile error = errors.New("cowardly refusing to ingest an empty file")
 	// a tag contained 1+ of the characters contained in illegalTagCharacters
 	errInvalidTagCharacter error = fmt.Errorf("tags cannot contain any of the following characters: %v", illegalTagCharacters)
 )
@@ -22,7 +26,4 @@ func errNoFilesSpecified(script bool) error {
 		tail = " in script mode"
 	}
 	return fmt.Errorf("at least 1 path must be specified%v", tail)
-}
-func errBadTagCount(count uint) error {
-	return fmt.Errorf("tag count must be 1 or equal to the number of files specified (%v)", count)
 }

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -12,10 +12,17 @@ var (
 	errEmptyFile error = errors.New("you must select a valid file for ingestion")
 	// a tag contained 1+ of the characters contained in illegalTagCharacters
 	errInvalidTagCharacter error = fmt.Errorf("tags cannot contain any of the following characters: %v", illegalTagCharacters)
-	// returned by autoingest if no file paths were given
-	errNoFilesSpecified error = errors.New("at least 1 file path must be specified")
 )
 
+// returned by autoingest if no file paths were given.
+// If script is specified, " in script mode" will be appended.
+func errNoFilesSpecified(script bool) error {
+	tail := ""
+	if script {
+		tail = " in script mode"
+	}
+	return fmt.Errorf("at least 1 path must be specified%v", tail)
+}
 func errBadTagCount(count uint) error {
 	return fmt.Errorf("tag count must be 1 or equal to the number of files specified (%v)", count)
 }

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -8,14 +8,16 @@ import (
 var illegalTagCharacters = []rune{' '}
 
 var (
-	//errEmptyTag  error = errors.New("tag cannot be empty")
-
 	// file path cannot be empty
 	errEmptyPath error = errors.New("file path cannot be empty")
 	// refusing to ingest an empty file
 	errEmptyFile error = errors.New("cowardly refusing to ingest an empty file")
 	// a tag contained 1+ of the characters contained in illegalTagCharacters
 	errInvalidTagCharacter error = fmt.Errorf("tags cannot contain any of the following characters: %v", illegalTagCharacters)
+	// a
+	errNoTagSpecified error = errors.New(
+		"every file must have a tag in at least one of the following positions (ordered by priority): " +
+			"as part of the argument (\"path,tag\"), embedded in the file (in the case of Gravwell JSON files), or via the --default-tag flag")
 )
 
 // returned by autoingest if no file paths were given.

--- a/gwcli/tree/ingest/errors.go
+++ b/gwcli/tree/ingest/errors.go
@@ -33,7 +33,7 @@ func init() {
 		sb.WriteString("'" + string(r) + "'" + ",")
 	}
 
-	errInvalidTagCharacter = fmt.Errorf("tags cannot contain any of the following characters: %v", sb.String()[:sb.Len()-1]) // chip the last comma
+	errInvalidTagCharacter = fmt.Errorf("tags cannot contain any of the following characters:\n%v", sb.String()[:sb.Len()-1]) // chip the last comma
 }
 
 // returned by autoingest if no file paths were given.

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -116,7 +116,8 @@ func run(c *cobra.Command, args []string) {
 		error
 	})
 
-	if count := autoingest(resultCh, flags, pairs); count == 0 {
+	count := autoingest(resultCh, flags, pairs)
+	if count == 0 {
 		// should be impossible
 		panic("autoingest returned a count of 0")
 	}
@@ -132,7 +133,7 @@ func run(c *cobra.Command, args []string) {
 		go func() { spinner.Run() }()
 	}
 	// print each result to stdout/stderr
-	for range pairs {
+	for range count {
 		res := <-resultCh
 		if res.error != nil {
 			clilog.Tee(clilog.WARN, c.ErrOrStderr(), fmt.Sprintf("failed to ingest file '%v': %v\n", res.string, res.error))

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -27,10 +27,12 @@ var (
 	helpDesc = "Ingest files into Gravwell.\n" +
 		"An arbitrary number of arguments can be specified, each of which takes the form: " + ft.Mandatory("path") + ft.Optional(",tag") + "\n" +
 		"If no flag is specified for a path, ingest will attempt to use the flag specified by --default-tag.\n" +
-		"The path can point to a single file or a directory; if it is the latter, ingest will recursively walk the directory to upload every file.\n" +
+		"The path can point to a single file or a directory; if it is the latter, ingest will shallowly walk the directory to upload each immediate file (unless -r is specified, then it will traverse recursively).\n" +
 		"Note, however, that ingest provides special handling for Gravwell JSON files.\n" +
 		"Gravwell JSON files typically have a tag built into them, which will be used instead of --default-tag if a tag is not specified as part of the argument.\n" +
-		"Calling ingest with no arguments will spin up a file picker (unless --script is specified in which case it will fail out)."
+		"\n" +
+		"Calling ingest with no arguments will spin up a file picker (unless --script is specified in which case it will fail out).\n" +
+		"Use --dir to specify a starting directory (otherwise pwd will be used)."
 )
 
 // NewIngestAction does as it says on the tin, enabling the caller to insert the returned pair into the action map.
@@ -54,13 +56,13 @@ func NewIngestAction() action.Pair {
 func initialLocalFlagSet() pflag.FlagSet {
 	fs := pflag.FlagSet{}
 
-	fs.StringP("src", "s", "", "IP address to use as the source of these files")
+	fs.BoolP("hidden", "h", false, "include hidden files when ingesting a directory")
+	fs.BoolP("recursive", "r", false, "recursively traverse directories, ingesting each file at every level")
+
+	fs.IPP("src", "s", nil, "IP address to use as the source of these files")
 	fs.Bool("ignore-timestamp", false, "all entries will be tagged with the current time")
 	fs.Bool("local-time", false, "any timezone information in the data will be ignored and "+
 		"timestamps will be assumed to be in the Gravwell server's local timezone")
-	fs.StringSliceP("tags", "t", nil, "comma-separated tags to apply to a file/file=s.\n"+
-		"If a single tag is specified, it will be applied to all files being ingested.\n"+
-		"If multiple tags are specified, they will be matched index-for-index with the files given.")
 	fs.StringP("dir", "d", "", "directory to start the interactive file picker in. Has no effect in script mode.")
 
 	return fs

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -116,9 +116,9 @@ func run(c *cobra.Command, args []string) {
 		error
 	})
 
-	if err := autoingest(resultCh, flags, pairs); err != nil {
-		fmt.Fprintln(c.ErrOrStderr(), stylesheet.Cur.ErrorText.Render(err.Error()))
-		return
+	if count := autoingest(resultCh, flags, pairs); count == 0 {
+		// should be impossible
+		panic("autoingest returned a count of 0")
 	}
 
 	// start up a spinner
@@ -134,7 +134,7 @@ func run(c *cobra.Command, args []string) {
 	// print each result to stdout/stderr
 	for range pairs {
 		res := <-resultCh
-		if res.error == nil {
+		if res.error != nil {
 			clilog.Tee(clilog.WARN, c.ErrOrStderr(), fmt.Sprintf("failed to ingest file '%v': %v\n", res.string, res.error))
 		} else {
 			fmt.Fprintf(c.OutOrStdout(), "successfully ingested file '%v'\n", res.string)

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -57,8 +57,8 @@ func NewIngestAction() action.Pair {
 func initialLocalFlagSet() pflag.FlagSet {
 	fs := pflag.FlagSet{}
 
-	fs.Bool("hidden", false,
-		"include hidden files when ingesting a directory")
+	/*fs.Bool("hidden", false,
+	"include hidden files when ingesting a directory")*/
 	fs.BoolP("recursive", "r", false,
 		"recursively traverse directories, ingesting each file at every level")
 

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -145,36 +145,4 @@ func run(c *cobra.Command, args []string) {
 	if spinner != nil {
 		spinner.Kill()
 	}
-
-	/*
-		done := make(chan bool) // close up shop, all files have been handled when closed
-
-		go func() { // await results, print them, then notify us when all have been consumed
-			for range files {
-				res := <-resultCh
-				if res.error != nil {
-					clilog.Tee(clilog.WARN, c.ErrOrStderr(), fmt.Sprintf("failed to ingest file '%v': %v\n", res.string, res.error))
-				} else {
-					fmt.Fprintf(c.OutOrStdout(), "successfully ingested file '%v'\n", res.string)
-				}
-			}
-			// all done
-			close(done)
-		}()
-
-		if script { // wait
-			<-done
-		} else { // wait and display a spinner
-			var s = "ingesting file"
-			if len(files) > 1 {
-				s += "s"
-			}
-			p := stylesheet.CobraSpinner(s)
-			go func() { p.Run() }()
-			<-done
-			p.Quit()
-		}
-
-		// all done
-	*/
 }

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -49,7 +49,7 @@ func NewIngestAction() action.Pair {
 		cmd.Flags().AddFlagSet(&fs)
 	}
 
-	return action.NewPair(cmd, Ingest)
+	return action.NewPair(cmd, Initial())
 
 }
 

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -87,7 +87,7 @@ func run(c *cobra.Command, args []string) {
 	// if no files were given, launch mother or fail out
 	if len(pairs) == 0 {
 		if flags.script {
-			fmt.Fprintln(c.ErrOrStderr(), "at least one path must be specified in script mode")
+			fmt.Fprintln(c.ErrOrStderr(), errNoFilesSpecified(true))
 			return
 		}
 
@@ -105,7 +105,7 @@ func run(c *cobra.Command, args []string) {
 		error
 	})
 
-	if err := autoingest(resultCh, files, tags, ignoreTS, localTime, src); err != nil {
+	if err := autoingest(resultCh, flags, pairs); err != nil {
 		fmt.Fprintln(c.ErrOrStderr(), stylesheet.Cur.ErrorText.Render(err.Error()))
 		return
 	}

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -7,6 +7,7 @@
  **************************************************************************/
 
 // Package ingest provides an action for streaming data TO Gravwell (as opposed to most other actions that operate in reverse).
+// File paths and tags can be specified as bare arguments and have the form "path,tag", where tag and the splitting comma are optional (in some cases).
 package ingest
 
 import (
@@ -55,19 +56,28 @@ func NewIngestAction() action.Pair {
 func initialLocalFlagSet() pflag.FlagSet {
 	fs := pflag.FlagSet{}
 
-	fs.BoolP("hidden", "h", false, "include hidden files when ingesting a directory")
-	fs.BoolP("recursive", "r", false, "recursively traverse directories, ingesting each file at every level")
+	fs.BoolP("hidden", "h", false,
+		"include hidden files when ingesting a directory")
+	fs.BoolP("recursive", "r", false,
+		"recursively traverse directories, ingesting each file at every level")
 
-	fs.StringP("source", "s", "", "IP address to use as the source of these files")
-	fs.Bool("ignore-timestamp", false, "all entries will be tagged with the current time")
-	fs.Bool("local-time", false, "any timezone information in the data will be ignored and "+
-		"timestamps will be assumed to be in the Gravwell server's local timezone")
-	fs.StringP("dir", "d", "", "directory to start the interactive file picker in. Has no effect in script mode.")
+	fs.StringP("source", "s", "",
+		"IP address to use as the source of these files")
+	fs.Bool("ignore-timestamp", false,
+		"all entries will be tagged with the current time")
+	fs.Bool("local-time", false,
+		"any timezone information in the data will be ignored and "+
+			"timestamps will be assumed to be in the Gravwell server's local timezone")
+	fs.String("dir", "",
+		"directory to start the interactive file picker in. Has no effect in script mode.")
+	fs.StringP("default-tag", "t", "",
+		"tag to use for each file that does not have one specified (either in the argument or embedded in the JSON (in the case of Gravwell JSON files))")
 
 	return fs
 }
 
 // driver subroutine invoked by Cobra when ingest is called from an external shell.
+// run boots Mother if !script && no files were specified; otherwise it attempts to autoingest the files.
 func run(c *cobra.Command, args []string) {
 	// fetch flags
 	flags, invalids, err := transmogrifyFlags(c.Flags())

--- a/gwcli/tree/ingest/ingest.go
+++ b/gwcli/tree/ingest/ingest.go
@@ -41,7 +41,7 @@ func NewIngestAction() action.Pair {
 		"ingest",
 		"ingest data from a file or STDIN",
 		helpDesc, []string{"in", "sip", "read"}, run)
-	cmd.Example = fmt.Sprintf("./gwcli ingest picture/of/space.png,pulsar query_results.json cat/pics/,animals ...")
+	cmd.Example = "./gwcli ingest picture/of/space.png,pulsar query_results.json cat/pics/,animals ..."
 
 	{ // install flags
 		fs := initialLocalFlagSet()

--- a/gwcli/tree/ingest/ingest_ci_test.go
+++ b/gwcli/tree/ingest/ingest_ci_test.go
@@ -1,0 +1,132 @@
+/*************************************************************************
+ * Copyright 2025 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package ingest
+
+// Carries tests that can be run without a backend.
+
+import (
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/Pallinder/go-randomdata"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/testsupport"
+)
+
+func Test_parsePairs(t *testing.T) {
+	var (
+		p1 = randomdata.LastName()
+		p2 = randomdata.LastName()
+		p3 = randomdata.LastName()
+
+		t1 = randomdata.Month()
+		t2 = randomdata.Month()
+		t3 = randomdata.Month()
+	)
+
+	type args struct {
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []pair
+	}{
+		{"none", args{[]string{}}, []pair{}},
+		{"empty strings", args{[]string{"", "", ""}}, []pair{}},
+		{"all w/ tags", args{[]string{p1 + "," + t1, p2 + "," + t2, p3 + "," + t3}}, []pair{{p1, t1}, {p2, t2}, {p3, t3}}},
+		{"mixed", args{[]string{p1 + "," + t1, p2}}, []pair{{p1, t1}, {path: p2}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePairs(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parsePairs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_collectPathsForIngestions(t *testing.T) {
+	// create a directory structure to test on
+	// |-tempdir
+	// 		|- fileA
+	//		|- fileB
+	//		|- fileC
+	//		|- childDir
+	//			|- fileZ
+	//			|- grandchildDir
+	//				|- fileX
+	dir := t.TempDir()
+	if err := os.MkdirAll(path.Join(dir, "childDir", "grandchildDir"), 0700); err != nil {
+		t.Fatal("failed to create test directories:", err)
+	}
+	if err := os.WriteFile(path.Join(dir, "fileA"), []byte("Hello WorldA"), 0622); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	if err := os.WriteFile(path.Join(dir, "fileB"), []byte("Hello WorldB"), 0622); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	if err := os.WriteFile(path.Join(dir, "fileC"), []byte("Hello WorldC"), 0622); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	if err := os.WriteFile(path.Join(dir, "childDir", "fileZ"), []byte("Hello WorldZ"), 0622); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	if err := os.WriteFile(path.Join(dir, "childDir", "grandchildDir", "fileX"), []byte("Hello WorldX"), 0622); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	type args struct {
+		pathToIngest string
+		recur        bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]bool
+		wantErr bool
+	}{
+		{"shallow", args{dir, false}, map[string]bool{
+			path.Join(dir, "fileA"): true,
+			path.Join(dir, "fileB"): true,
+			path.Join(dir, "fileC"): true,
+		}, false},
+		{"shallow subdir", args{path.Join(dir, "childDir"), false}, map[string]bool{
+			path.Join(dir, "childDir", "fileZ"): true,
+		}, false},
+		{"single file", args{path.Join(dir, "fileA"), false}, map[string]bool{
+			path.Join(dir, "fileA"): true,
+		}, false},
+		{"recursive", args{dir, true}, map[string]bool{
+			path.Join(dir, "fileA"):                              true,
+			path.Join(dir, "fileB"):                              true,
+			path.Join(dir, "fileC"):                              true,
+			path.Join(dir, "childDir", "fileZ"):                  true,
+			path.Join(dir, "childDir", "grandchildDir", "fileX"): true,
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := collectPathsForIngestions(tt.args.pathToIngest, tt.args.recur)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("collectPathsForIngestions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("incorrect path counts.%v", testsupport.ExpectedActual(len(tt.want), len(got)))
+			}
+			for path := range got {
+				if _, exists := tt.want[path]; !exists {
+					t.Errorf("extraneous path %v in actual", path)
+				}
+			}
+		})
+	}
+}

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -61,7 +61,11 @@ func Test_autoingest(t *testing.T) {
 			1, map[string]bool{"hello": false}},
 		{"1 pair, no tag no default", args{[]pair{{"hello", ""}}, ingestFlags{script: true}},
 			1, map[string]bool{"hello": true}},
-		{"2 pairs", args{[]pair{{"file1", "tag1"}, {"dir/file2", "tag2"}}, ingestFlags{script: true}},
+		{"2 pairs",
+			args{
+				[]pair{{"file1", "tag1"}, {"dir/file2", "tag2"}},
+				ingestFlags{script: true},
+			},
 			2, map[string]bool{"file1": false, "dir/file2": false}},
 		/*{"2 pair, default tag"},
 		{"2 pairs,1 default 1 specified"},

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -67,8 +67,12 @@ func Test_autoingest(t *testing.T) {
 				ingestFlags{script: true},
 			},
 			2, map[string]bool{"file1": false, "dir/file2": false}},
-		/*{"2 pair, default tag"},
-		{"2 pairs,1 default 1 specified"},
+		{"2 pair, default tag",
+			args{
+				[]pair{{path: "Ironeye"}, {path: "Duchess"}},
+				ingestFlags{script: true, defaultTag: "Limveld"},
+			}, 2, map[string]bool{"Ironeye": false, "Duchess": false}},
+		/*{"2 pairs,1 default 1 specified"},
 		{"4 pairs,1 specified, no default"},
 		{""},
 		{"Gravwell SJON"}, // TODO break into separate subroutine and create a GWJSON file

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -281,7 +281,7 @@ func Test_autoingest(t *testing.T) {
 // The tag will not be returned by GetTags until files under it have been committed.
 func verifyTagExists(t *testing.T, tag string) bool {
 	t.Helper()
-	time.Sleep(5 * time.Second) // tags can take a few moments to show up
+	time.Sleep(10 * time.Second) // tags can take a few moments to show up
 	tags, err := connection.Client.GetTags()
 	if err != nil {
 		t.Error(err)

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -243,6 +243,21 @@ func TestNewIngestActionRun(t *testing.T) {
 				return true
 			},
 		},
+		{"--dir given non-existent path",
+			[]string{"--dir", "/nonsense_path"},
+			func() (success bool) { return true },
+			func(out, err string) (success bool) { return err != "" },
+		},
+		{"--dir given file",
+			[]string{"--dir", "/nonsense_path"},
+			func() (success bool) { return true },
+			func(out, err string) (success bool) { return err != "" },
+		},
+		{"--dir given with --script",
+			[]string{"--dir", "/tmp", "--script"},
+			func() (success bool) { return true },
+			func(out, err string) (success bool) { return err != "" },
+		},
 		/*
 			{"2 files, 1 tag",
 				[]string{"--tags=Limveld", path.Join(dir, "raider"), path.Join(dir, "recluse")},
@@ -316,11 +331,6 @@ func TestNewIngestActionRun(t *testing.T) {
 					}
 					return true
 				},
-			},
-			{"--dir given non-existent path",
-				[]string{"--dir", "/nonsense_path"},
-				func() (success bool) { return true },
-				func(out, err string) (success bool) { return err != "" },
 			},
 		*/
 	}

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -73,36 +73,6 @@ func Test_autoingest(t *testing.T) {
 				[]pair{{path: "Ironeye"}, {path: "Duchess"}},
 				ingestFlags{script: true, defaultTag: "Limveld"},
 			}, 2, map[string]bool{"Ironeye": false, "Duchess": false}},
-		/*{"2 pairs,1 default 1 specified"},
-		{"4 pairs,1 specified, no default"},
-		{""},
-		{"Gravwell SJON"}, // TODO break into separate subroutine and create a GWJSON file
-
-		{"1 file, 5 tags",
-			args{
-				[]string{"Ironeye"},
-				[]string{randomdata.Day(), randomdata.Day(), randomdata.Day(), randomdata.Day(), randomdata.Day()},
-				false,
-				false,
-				""}, true, map[string]bool{"Ironeye": true}},
-		{"1 file, 1 tag",
-			args{
-				[]string{"Duchess"},
-				[]string{randomdata.Month()},
-				false,
-				false,
-				"",
-			}, false, map[string]bool{"Duchess": false},
-		},
-		{"3 files, 3 tags",
-			args{
-				[]string{"Revenant", "Wylder", "Guardian"},
-				[]string{randomdata.Month(), randomdata.Month(), randomdata.Month()},
-				true,
-				true,
-				randomdata.IpV6Address(),
-			}, false, map[string]bool{"Revenant": false, "Wylder": false, "Guardian": false},
-		},*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -440,7 +440,7 @@ func TestNewIngestActionRun(t *testing.T) {
 
 	t.Run("Gravwell JSON", func(t *testing.T) {
 		var (
-			tag1, tag2, tag3 = randomdata.City(), randomdata.Digits(5), randomdata.Title(0)
+			tag1, tag2, tag3 = "Millhouse", randomdata.Digits(5), randomdata.LastName()
 			gwjson           = `{"TS":"2025-06-26T23:26:56.100667099Z","Tag":"` + tag1 + `","SRC":"172.17.0.1","Data":"SGVsbG8gV29ybGRD","Enumerated":null}
 {"TS":"2025-06-26T23:26:56.100640318Z","Tag":"` + tag2 + `","SRC":"172.17.0.1","Data":"SGVsbG8gV29ybGRB","Enumerated":null}
 {"TS":"2025-06-26T23:26:56.100091382Z","Tag":"` + tag3 + `","SRC":"172.17.0.1","Data":"SGVsbG8gV29ybGRC","Enumerated":null}`
@@ -453,6 +453,8 @@ func TestNewIngestActionRun(t *testing.T) {
 		if err := os.WriteFile(jsonpath, []byte(gwjson), 0600); err != nil {
 			t.Fatal("failed to write test json to file:", err)
 		}
+
+		t.Log("tags: ", tag1, tag2, tag3)
 
 		// create the action
 		ap := NewIngestAction()

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"os"
 	"path"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -265,39 +264,6 @@ func verifyTagExists(t *testing.T, tag string) bool {
 	return false
 }
 
-func Test_parsePairs(t *testing.T) {
-	var (
-		p1 = randomdata.LastName()
-		p2 = randomdata.LastName()
-		p3 = randomdata.LastName()
-
-		t1 = randomdata.Month()
-		t2 = randomdata.Month()
-		t3 = randomdata.Month()
-	)
-
-	type args struct {
-		args []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []pair
-	}{
-		{"none", args{[]string{}}, []pair{}},
-		{"empty strings", args{[]string{"", "", ""}}, []pair{}},
-		{"all w/ tags", args{[]string{p1 + "," + t1, p2 + "," + t2, p3 + "," + t3}}, []pair{{p1, t1}, {p2, t2}, {p3, t3}}},
-		{"mixed", args{[]string{p1 + "," + t1, p2}}, []pair{{p1, t1}, {path: p2}}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := parsePairs(tt.args.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parsePairs() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestNewIngestActionRun is very similar to autoingest, but includes the manual creation and execution of the cobra command.
 func TestNewIngestActionRun(t *testing.T) {
 	if err := clilog.Init(path.Join(t.TempDir(), "dev.log"), "debug"); err != nil {
@@ -486,82 +452,4 @@ func TestNewIngestActionRun(t *testing.T) {
 			t.Errorf("bad output. Expected to contain the path %v", jsonpath)
 		}
 	})
-}
-
-func Test_collectPathsForIngestions(t *testing.T) {
-	// create a directory structure to test on
-	// |-tempdir
-	// 		|- fileA
-	//		|- fileB
-	//		|- fileC
-	//		|- childDir
-	//			|- fileZ
-	//			|- grandchildDir
-	//				|- fileX
-	dir := t.TempDir()
-	if err := os.MkdirAll(path.Join(dir, "childDir", "grandchildDir"), 0700); err != nil {
-		t.Fatal("failed to create test directories:", err)
-	}
-	if err := os.WriteFile(path.Join(dir, "fileA"), []byte("Hello WorldA"), 0622); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	if err := os.WriteFile(path.Join(dir, "fileB"), []byte("Hello WorldB"), 0622); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	if err := os.WriteFile(path.Join(dir, "fileC"), []byte("Hello WorldC"), 0622); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	if err := os.WriteFile(path.Join(dir, "childDir", "fileZ"), []byte("Hello WorldZ"), 0622); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	if err := os.WriteFile(path.Join(dir, "childDir", "grandchildDir", "fileX"), []byte("Hello WorldX"), 0622); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-
-	type args struct {
-		pathToIngest string
-		recur        bool
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    map[string]bool
-		wantErr bool
-	}{
-		{"shallow", args{dir, false}, map[string]bool{
-			path.Join(dir, "fileA"): true,
-			path.Join(dir, "fileB"): true,
-			path.Join(dir, "fileC"): true,
-		}, false},
-		{"shallow subdir", args{path.Join(dir, "childDir"), false}, map[string]bool{
-			path.Join(dir, "childDir", "fileZ"): true,
-		}, false},
-		{"single file", args{path.Join(dir, "fileA"), false}, map[string]bool{
-			path.Join(dir, "fileA"): true,
-		}, false},
-		{"recursive", args{dir, true}, map[string]bool{
-			path.Join(dir, "fileA"):                              true,
-			path.Join(dir, "fileB"):                              true,
-			path.Join(dir, "fileC"):                              true,
-			path.Join(dir, "childDir", "fileZ"):                  true,
-			path.Join(dir, "childDir", "grandchildDir", "fileX"): true,
-		}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := collectPathsForIngestions(tt.args.pathToIngest, tt.args.recur)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("collectPathsForIngestions() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if len(got) != len(tt.want) {
-				t.Errorf("incorrect path counts.%v", testsupport.ExpectedActual(len(tt.want), len(got)))
-			}
-			for path := range got {
-				if _, exists := tt.want[path]; !exists {
-					t.Errorf("extraneous path %v in actual", path)
-				}
-			}
-		})
-	}
 }

--- a/gwcli/tree/ingest/ingest_test.go
+++ b/gwcli/tree/ingest/ingest_test.go
@@ -394,81 +394,44 @@ func TestNewIngestActionRun(t *testing.T) {
 			func() (success bool) { return true },
 			func(out, err string) (success bool) { return err != "" },
 		},
-		/*
-			{"2 files, 1 tag",
-				[]string{"--tags=Limveld", path.Join(dir, "raider"), path.Join(dir, "recluse")},
-				func() bool {
-					// create the files to ingest
-					if err := os.WriteFile(path.Join(dir, "raider"), []byte(randomdata.Paragraph()), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
-					if err := os.WriteFile(path.Join(dir, "recluse"), []byte(randomdata.StringNumber(40, "\n")), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
+		{"invalid source",
+			[]string{"--source", "badsrc", "--script"},
+			func() (success bool) { return true },
+			func(out, err string) (success bool) { return err != "" },
+		},
+		{"invalid default tag",
+			[]string{"--default-tag", "some|tag", "--script"},
+			func() (success bool) { return true },
+			func(out, err string) (success bool) { return err != "" },
+		},
+		{"2 files, 1 invalid tag",
+			[]string{"--ignore-timestamp", path.Join(dir, "raider,Limveld"), path.Join(dir, "recluse,bad|tag")},
+			func() bool {
+				// create the files to ingest
+				if err := os.WriteFile(path.Join(dir, "raider"), []byte(randomdata.Paragraph()), 0644); err != nil {
+					t.Log(err)
+					return false
+				}
+				// this file should *not* be ingested
+				if err := os.WriteFile(path.Join(dir, "recluse"), []byte(randomdata.StringNumber(40, "\n")), 0644); err != nil {
+					t.Log(err)
+					return false
+				}
 
-					return true
-				},
-				func(out, err string) bool {
-					if err != "" {
-						t.Logf("expected nil err output, found %v", err)
-						return false
-					}
-					return true
-				},
+				return true
 			},
-			{"2 files, 2 tags, with bools",
-				[]string{"--tags=Limveld,Night", "--ignore-timestamp", path.Join(dir, "raider"), path.Join(dir, "recluse")},
-				func() bool {
-					// create the files to ingest
-					if err := os.WriteFile(path.Join(dir, "raider"), []byte(randomdata.Paragraph()), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
-					if err := os.WriteFile(path.Join(dir, "recluse"), []byte(randomdata.StringNumber(40, "\n")), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
-
-					return true
-				},
-				func(out, err string) bool {
-					if err != "" {
-						t.Logf("expected nil err output, found %v", err)
-						return false
-					}
-					return true
-				},
+			func(out, err string) bool {
+				if len(strings.Split(out, "\n")) == 1 {
+					t.Logf("expected expected output to have exactly 1 record, found %v from %v", len(out), out)
+					return false
+				}
+				if err == "" {
+					t.Log("expected error text, found nil")
+					return false
+				}
+				return true
 			},
-			{"2 files, 2 (invalid) tags",
-				[]string{"--tags=|/,[]", "--ignore-timestamp", path.Join(dir, "raider"), path.Join(dir, "recluse")},
-				func() bool {
-					// create the files to ingest
-					if err := os.WriteFile(path.Join(dir, "raider"), []byte(randomdata.Paragraph()), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
-					if err := os.WriteFile(path.Join(dir, "recluse"), []byte(randomdata.StringNumber(40, "\n")), 0644); err != nil {
-						t.Log(err)
-						return false
-					}
-
-					return true
-				},
-				func(out, err string) bool {
-					if out != "" {
-						t.Logf("expected nil output, found %v", out)
-						return false
-					}
-					if err == "" {
-						t.Log("expected error text, found nil")
-						return false
-					}
-					return true
-				},
-			},
-		*/
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gwcli/tree/ingest/modView.go
+++ b/gwcli/tree/ingest/modView.go
@@ -169,6 +169,7 @@ func (m mod) reset() mod {
 	m.ignoreTS = false
 	m.localTime = false
 
+	m.selected = src
 	m.srcTI.Focus()
 	m.tagTI.Blur()
 

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -22,7 +22,7 @@ import (
 )
 
 // autoingest attempts to ingest the data at each path, returning errors and successes on the given channel (if non-nil).
-// Performs ingestions in parallel; once len(filepaths) results have been send (cumulative across both channels), caller can assume this goroutine has returned.
+// Performs ingestions in parallel; once len(filepaths) results have been sent, caller can assume this goroutine has returned.
 // No logging is performed internally; caller is expected to log and present results.
 //
 // If ufErr (user-friendly error) is returned, do not wait on the channel; no values will be sent.
@@ -33,8 +33,8 @@ func autoingest(res chan<- struct {
 	path string
 	tag  string
 }) (ufErr error) {
-	if len(paths) == 0 {
-		return errNoFilesSpecified
+	if len(pairs) == 0 {
+		return errNoFilesSpecified(flags.script)
 	}
 	// check that tag len is 1 or == file len
 	if len(tags) != 1 && len(tags) != len(paths) {

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -29,7 +29,10 @@ import (
 func autoingest(res chan<- struct {
 	string
 	error
-}, paths, tags []string, ignoreTS, localTime bool, src string) (ufErr error) {
+}, flags ingestFlags, pairs []struct {
+	path string
+	tag  string
+}) (ufErr error) {
 	if len(paths) == 0 {
 		return errNoFilesSpecified
 	}

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -113,15 +113,15 @@ func transmogrifyFlags(fs *pflag.FlagSet) (ingestFlags, []string, error) {
 	}
 	if srcRaw, err := fs.GetString("source"); err != nil {
 		return flags, invalids, uniques.ErrFlagDNE("source", "ingest")
-	} else if src := net.ParseIP(srcRaw); src == nil {
-		invalids = append(invalids, srcRaw+" is not a valid IP address")
-	} else {
-		if src == nil {
-			flags.src = ""
+	} else if srcRaw != "" {
+		if src := net.ParseIP(srcRaw); src == nil {
+			invalids = append(invalids, srcRaw+" is not a valid IP address")
 		} else {
 			flags.src = src.String()
+
 		}
 	}
+
 	if ignoreTS, err := fs.GetBool("ignore-timestamp"); err != nil {
 		return flags, invalids, uniques.ErrFlagDNE("ignore-timestamp", "ingest")
 	} else {

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -148,6 +148,8 @@ func transmogrifyFlags(fs *pflag.FlagSet) (ingestFlags, []string, error) {
 	}
 	if def, err := fs.GetString("default-tag"); err != nil {
 		return flags, invalids, uniques.ErrFlagDNE("default-tag", "ingest")
+	} else if err := validateTag(def); err != nil {
+		return flags, invalids, err
 	} else {
 		flags.defaultTag = def
 	}

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -212,11 +212,11 @@ func ingestPath(flags ingestFlags, p pair) error {
 
 // determineTag figures out which tag to use, following the given priority:
 //
-// 1)
+// 1) tag included in the pair (parsed from the bare arguments given)
 //
-// 2)
+// 2) tag embedded into the file (in the case of a GWJSON)
 //
-// 3)
+// 3) default tag given via --default-tag
 //
 // ! It is valid for this function to return an empty tag and a nil error.
 // This just means the file is a valid GWJSON file and can be ingested with the empty tag.
@@ -230,7 +230,7 @@ func determineTag(p pair, defaultTag string) (string, error) {
 			}
 			dcdr := json.NewDecoder(f)
 			var ste types.StringTagEntry
-			// try to decode a single entry (\n deliminted)
+			// try to decode a single entry (\n delimited)
 			if err := dcdr.Decode(&ste); err == nil && ste.Tag != "" {
 				// successfully decoded file and read tag; we can leave our tag empty
 				return "", nil

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -144,8 +144,8 @@ func validateDirFlag(dir string) (invalid string, err error) {
 
 // ingestFlags holds all flags so we don't have to keep passing around the pflag set.
 type ingestFlags struct {
-	script     bool
-	hidden     bool   // include hidden files when ingesting directories
+	script bool
+	//hidden     bool   // include hidden files when ingesting directories
 	recursive  bool   // recursively descend directories
 	src        string // IP address to use as the source of the files; comes in as a net.IP
 	ignoreTS   bool   // all entries will be tagged with the current time rather than any internal timestamping.
@@ -174,11 +174,11 @@ func transmogrifyFlags(fs *pflag.FlagSet) (ingestFlags, []string, error) {
 	} else {
 		flags.script = script
 	}
-	if includeHidden, err := fs.GetBool("hidden"); err != nil {
+	/*if includeHidden, err := fs.GetBool("hidden"); err != nil {
 		return flags, nil, uniques.ErrFlagDNE("hidden", "ingest")
 	} else {
 		flags.hidden = includeHidden
-	}
+	}*/
 	if recursive, err := fs.GetBool("recursive"); err != nil {
 		return flags, nil, uniques.ErrFlagDNE("recursive", "ingest")
 	} else {

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -271,33 +271,6 @@ func ingestPath(flags ingestFlags, pth, tag string) error {
 	return ingestFile(pth, tag, flags)
 }
 
-// given a directory, walkDir ingests each file within and, if recur, recursively ingests each file in each subdirectory.
-// Halts on the first error.
-//
-// Single-threaded.
-func walkDir(dirpath string, tag string, flags ingestFlags) error {
-	// Recursive ingestion is depth-first (entering directories as soon as they are found).
-
-	entries, err := os.ReadDir(dirpath)
-	if err != nil {
-		clilog.Writer.Warnf("failed to walk directory rooted at %v: %v", dirpath, err)
-		return err
-	}
-	for _, entry := range entries {
-		if entry.IsDir() && flags.recursive { // if it is a directory, ignore it or enter it (depending on -r)
-			if err := walkDir(path.Join(dirpath, entry.Name()), tag, flags); err != nil {
-				return err
-			}
-		} else if !entry.IsDir() { // if this is a file, ingest it
-			// recompose full path and ingest
-			if err := ingestFile(path.Join(dirpath, entry.Name()), tag, flags); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // wrapper for Client.IngestFile that logs and returns the outcome.
 func ingestFile(path, tag string, flags ingestFlags) error {
 	resp, err := connection.Client.IngestFile(path, tag, flags.src, flags.ignoreTS, flags.localTime)

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -72,6 +72,7 @@ func validateDirFlag(dir string) (invalid string, err error) {
 	return "", nil
 }
 
+// ingestFlags holds all flags so we don't have to keep passing around the pflag set.
 type ingestFlags struct {
 	script     bool
 	hidden     bool   // include hidden files when ingesting directories
@@ -145,6 +146,8 @@ func transmogrifyFlags(fs *pflag.FlagSet) (ingestFlags, []string, error) {
 	}
 	if def, err := fs.GetString("default-tag"); err != nil {
 		return flags, invalids, uniques.ErrFlagDNE("default-tag", "ingest")
+	} else {
+		flags.defaultTag = def
 	}
 
 	return flags, invalids, nil
@@ -213,8 +216,9 @@ func ingestPath(flags ingestFlags, pair struct {
 		clilog.Writer.Warnf("failed to ingest %v at path %v: %v", fileOrDirStr, pair.path, err)
 		return err
 	}
-	// TODO
-
+	clilog.Writer.Infof("successfully ingested %v at path %v (specified tag: %v | returned tags: %v)",
+		fileOrDirStr, pair.path, pair.tag, resp.Tags)
+	return nil
 }
 
 // determineTag figures out which tag to use, following the given priority:

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -170,17 +170,17 @@ func transmogrifyFlags(fs *pflag.FlagSet) (ingestFlags, []string, error) {
 	flags := ingestFlags{}
 
 	if script, err := fs.GetBool("script"); err != nil {
-		return flags, invalids, uniques.ErrFlagDNE("script", "ingest")
+		return flags, nil, uniques.ErrFlagDNE("script", "ingest")
 	} else {
 		flags.script = script
 	}
 	if includeHidden, err := fs.GetBool("hidden"); err != nil {
-		return flags, invalids, uniques.ErrFlagDNE("hidden", "ingest")
+		return flags, nil, uniques.ErrFlagDNE("hidden", "ingest")
 	} else {
 		flags.hidden = includeHidden
 	}
 	if recursive, err := fs.GetBool("recursive"); err != nil {
-		return flags, invalids, uniques.ErrFlagDNE("recursive", "ingest")
+		return flags, nil, uniques.ErrFlagDNE("recursive", "ingest")
 	} else {
 		flags.recursive = recursive
 	}

--- a/gwcli/tree/ingest/shared.go
+++ b/gwcli/tree/ingest/shared.go
@@ -243,13 +243,20 @@ func determineTag(p pair, defaultTag string) (string, error) {
 		}
 		return p.tag, nil
 	}
-	// validate the argument tag
-	for _, r := range p.tag {
-		if slices.Contains(illegalTagCharacters, r) {
-			return "", errInvalidTagCharacter
-		}
+	if err := validateTag(p.tag); err != nil {
+		return "", err
 	}
 	return p.tag, nil
+}
+
+func validateTag(tag string) error {
+	// validate the argument tag
+	for _, r := range tag {
+		if slices.Contains(illegalTagCharacters, r) {
+			return errInvalidTagCharacter
+		}
+	}
+	return nil
 }
 
 type pair struct {


### PR DESCRIPTION
Redo the script version of ingest for better usability and improved features. Non-interactive ingest can now traverse directories and infer tags from gravwell JSON files and consumes input in a less error-prone manner.